### PR TITLE
Add provider selection logic, file provider and tests

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,13 +48,13 @@ var sanitizeEnv = []string{
 	"VAULT_ENV_PASSTHROUGH",
 }
 
-func (e *sanitizedEnviron) append(name string, value string) {
-	for _, env := range sanitizeEnv {
-		if name == env {
-			e.env = append(e.env, fmt.Sprintf("%s=%s", name, value))
-		}
-	}
-}
+// func (e *sanitizedEnviron) append(name string, value string) {
+// 	for _, env := range sanitizeEnv {
+// 		if name == env {
+// 			e.env = append(e.env, fmt.Sprintf("%s=%s", name, value))
+// 		}
+// 	}
+// }
 
 func main() {
 	var logger *slog.Logger

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/spf13/cast"
 
 	"github.com/bank-vaults/secret-init/provider"
+	"github.com/bank-vaults/secret-init/provider/file"
 )
 
 func main() {
@@ -95,7 +96,17 @@ func main() {
 	}
 
 	// TODO: enable providers
-	var provider provider.Provider
+	providers := map[string]provider.Provider{
+		"file": file.NewFileProvider(os.Getenv("SECRETS_FILE_PATH")),
+	}
+
+	providerName := os.Getenv("PROVIDER")
+	provider, found := providers[providerName]
+	if !found {
+		logger.Error("invalid provider specified.", slog.String("provider name", providerName))
+
+		os.Exit(1)
+	}
 
 	if len(os.Args) == 1 {
 		logger.Error("no command is given, vault-env can't determine the entrypoint (command), please specify it explicitly or let the webhook query it (see documentation)")

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"slices"
+	"strings"
 	"syscall"
 	"time"
 
@@ -34,6 +35,26 @@ import (
 	"github.com/bank-vaults/secret-init/provider"
 	"github.com/bank-vaults/secret-init/provider/file"
 )
+
+type sanitizedEnviron struct {
+	env []string
+}
+
+var sanitizeEnv = []string{
+	"VAULT_JSON_LOG",
+	"VAULT_LOG_LEVEL",
+	"VAULT_ENV_DAEMON",
+	"VAULT_ENV_DELAY",
+	"VAULT_ENV_PASSTHROUGH",
+}
+
+func (e *sanitizedEnviron) append(name string, value string) {
+	for _, env := range sanitizeEnv {
+		if name == env {
+			e.env = append(e.env, fmt.Sprintf("%s=%s", name, value))
+		}
+	}
+}
 
 func main() {
 	var logger *slog.Logger
@@ -95,7 +116,6 @@ func main() {
 		slog.SetDefault(logger)
 	}
 
-	// TODO: enable providers
 	providers := map[string]provider.Provider{
 		"file": file.NewFileProvider(os.Getenv("SECRETS_FILE_PATH")),
 	}
@@ -126,13 +146,41 @@ func main() {
 		os.Exit(1)
 	}
 
+	passthroughEnvVars := strings.Split(os.Getenv("VAULT_ENV_PASSTHROUGH"), ",")
+
+	// do not sanitize env vars specified in VAULT_ENV_PASSTHROUGH
+	for _, envVar := range passthroughEnvVars {
+		if trimmed := strings.TrimSpace(envVar); trimmed != "" {
+			for i, sanEnv := range sanitizeEnv {
+				if trimmed == sanEnv {
+					sanitizeEnv[i] = sanitizeEnv[len(sanitizeEnv)-1]
+					sanitizeEnv[len(sanitizeEnv)-1] = ""
+					sanitizeEnv = sanitizeEnv[:len(sanitizeEnv)-1]
+				}
+			}
+		}
+	}
+
+	environ := make(map[string]string, len(os.Environ()))
+	sanitized := sanitizedEnviron{}
+
+	for _, env := range os.Environ() {
+		split := strings.SplitN(env, "=", 2)
+		name := split[0]
+		value := split[1]
+		environ[name] = value
+	}
+
 	ctx := context.Background()
-	envs, err := provider.LoadSecrets(ctx, os.Environ())
+	envs, err := provider.LoadSecrets(ctx, &environ)
 	if err != nil {
 		logger.Error("could not retrieve secrets from the provider.", err)
 
 		os.Exit(1)
 	}
+
+	// passthroughEnvs + loaded secrets
+	sanitized.env = append(sanitized.env, envs...)
 
 	sigs := make(chan os.Signal, 1)
 
@@ -146,7 +194,7 @@ func main() {
 	if daemonMode {
 		logger.Info("in daemon mode...")
 		cmd := exec.Command(binary, entrypointCmd[1:]...)
-		cmd.Env = append(os.Environ(), envs...)
+		cmd.Env = append(os.Environ(), sanitized.env...)
 		cmd.Stdin = os.Stdin
 		cmd.Stderr = os.Stderr
 		cmd.Stdout = os.Stdout
@@ -195,7 +243,7 @@ func main() {
 
 		os.Exit(cmd.ProcessState.ExitCode())
 	}
-	err = syscall.Exec(binary, entrypointCmd, envs)
+	err = syscall.Exec(binary, entrypointCmd, sanitized.env)
 	if err != nil {
 		logger.Error(fmt.Errorf("failed to exec process: %w", err).Error(), slog.String("entrypoint", fmt.Sprint(entrypointCmd)))
 

--- a/provider/file/file.go
+++ b/provider/file/file.go
@@ -1,0 +1,35 @@
+// Copyright © 2023 Bank-Vaults Maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"context"
+
+	"github.com/bank-vaults/secret-init/provider"
+)
+
+type FileProvider struct {
+	SecretsFilePath string
+}
+
+func NewFileProvider(secretsFilePath string) provider.Provider {
+
+	return &FileProvider{SecretsFilePath: secretsFilePath}
+}
+
+func (provider *FileProvider) LoadSecrets(ctx context.Context, paths []string) ([]string, error) {
+
+	return make([]string, 2), nil
+}

--- a/provider/file/file.go
+++ b/provider/file/file.go
@@ -29,7 +29,6 @@ func NewFileProvider(secretsFilePath string) provider.Provider {
 	return &Provider{SecretsFilePath: secretsFilePath}
 }
 
-func (provider *Provider) LoadSecrets(_ context.Context, paths []string) ([]string, error) {
-
-	return paths, nil
+func (provider *Provider) LoadSecrets(_ context.Context, paths *map[string]string) ([]string, error) {
+	return make([]string, 0), nil
 }

--- a/provider/file/file.go
+++ b/provider/file/file.go
@@ -31,5 +31,5 @@ func NewFileProvider(secretsFilePath string) provider.Provider {
 
 func (provider *Provider) LoadSecrets(_ context.Context, paths []string) ([]string, error) {
 
-	return make([]string, 2), nil
+	return paths, nil
 }

--- a/provider/file/file.go
+++ b/provider/file/file.go
@@ -20,16 +20,16 @@ import (
 	"github.com/bank-vaults/secret-init/provider"
 )
 
-type FileProvider struct {
+type Provider struct {
 	SecretsFilePath string
 }
 
 func NewFileProvider(secretsFilePath string) provider.Provider {
 
-	return &FileProvider{SecretsFilePath: secretsFilePath}
+	return &Provider{SecretsFilePath: secretsFilePath}
 }
 
-func (provider *FileProvider) LoadSecrets(ctx context.Context, paths []string) ([]string, error) {
+func (provider *Provider) LoadSecrets(_ context.Context, paths []string) ([]string, error) {
 
 	return make([]string, 2), nil
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -18,5 +18,5 @@ import "context"
 
 // Provider is an interface for securely loading secrets based on environment variables.
 type Provider interface {
-	LoadSecrets(ctx context.Context, paths []string) ([]string, error)
+	LoadSecrets(ctx context.Context, paths *map[string]string) ([]string, error)
 }


### PR DESCRIPTION
## Overview

This PR contains a file provider, with tests, and implemented provider selection logic.
The provider selection works by getting it from an environment variable.
The file provider gets the secrets file path from env-var also.

Continuation of issue: #1 