### PR TITLE
fix: handle different vault injection cases

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -27,7 +27,6 @@ const (
 	LogServerEnv = "SECRET_INIT_LOG_SERVER"
 	DaemonEnv    = "SECRET_INIT_DAEMON"
 	DelayEnv     = "SECRET_INIT_DELAY"
-	ProviderEnv  = "SECRET_INIT_PROVIDER"
 )
 
 type Config struct {

--- a/e2e/multi-provider.bats
+++ b/e2e/multi-provider.bats
@@ -28,9 +28,9 @@ setup_vault_provider() {
   export VAULT_ADDR="http://127.0.0.1:8200"
   export VAULT_TOKEN_FILE="$TMPFILE_TOKEN"
 
-  export MYSQL_PASSWORD=vault:secret/data/test/mysql#MYSQL_PASSWORD
-  export AWS_SECRET_ACCESS_KEY=vault:secret/data/test/aws#AWS_SECRET_ACCESS_KEY
-  export AWS_ACCESS_KEY_ID=vault:secret/data/test/aws#AWS_ACCESS_KEY_ID
+  export MYSQL_PASSWORD="vault:secret/data/test/mysql#MYSQL_PASSWORD"
+  export AWS_SECRET_ACCESS_KEY="vault:secret/data/test/aws#AWS_SECRET_ACCESS_KEY"
+  export AWS_ACCESS_KEY_ID="vault:secret/data/test/aws#AWS_ACCESS_KEY_ID"
 
   start_vault
 }

--- a/e2e/multi-provider.bats
+++ b/e2e/multi-provider.bats
@@ -63,22 +63,24 @@ add_secrets_to_vault() {
   docker exec "$vault_container_name" vault kv put secret/test/aws AWS_ACCESS_KEY_ID=secretId AWS_SECRET_ACCESS_KEY=s3cr3t
 }
 
-remove_secrets_from_vault() {
-  docker exec "$vault_container_name" vault kv delete secret/test/mysql
-  docker exec "$vault_container_name" vault kv delete secret/test/aws
+add_custom_secret_to_vault() {
+  local path="$1"
+  shift
+  local data=()
+
+  for secret in "$@"; do
+    data+=("$secret")
+  done
+
+  vault kv put "$path" "${data[@]}"
 }
 
 teardown() {
-  stop_vault
+  docker compose down
 
   rm -f "$TMPFILE_SECRET"
   rm -f "$TMPFILE_TOKEN"
   rm -f secret-init
-}
-
-stop_vault() {
-  remove_secrets_from_vault
-  docker compose down
 }
 
 assert_output_contains() {

--- a/e2e/multi-provider.bats
+++ b/e2e/multi-provider.bats
@@ -174,3 +174,34 @@ check_process_status() {
   assert_output_contains "AWS_ACCESS_KEY_ID=secretId" "$run_output"
   assert_output_contains "FILE_SECRET=secret-value" "$run_output"
 }
+
+@test "secrets successfully loaded using different injection cases" {
+  setup_file_provider
+
+  setup_vault_provider
+  set_vault_token 227e1cce-6bf7-30bb-2d2a-acc854318caf
+  add_secrets_to_vault
+
+  # Secret with version
+  add_custom_secret_to_vault "secret/test/mysql" "MYSQL_PASSWORD=modify3d3xtr3ms3cr3t"
+  export MYSQL_PASSWORD="vault:secret/data/test/mysql#MYSQL_PASSWORD#2"
+
+  # Inline secrets with scheme
+  add_custom_secret_to_vault "secret/test/scheme" "SCHEME_SECRET1=sch3m3s3cr3tONE" "SCHEME_SECRET2=sch3m3s3cr3tTWO"
+  export SCHEME_SECRET="scheme://\${vault:secret/data/test/scheme#SCHEME_SECRET1}:\${vault:secret/data/test/scheme#SCHEME_SECRET2}@$VAULT_ADDR"
+
+  # Enable pki secrets engine and generate root certificates
+  vault secrets enable -path=pki pki
+  export ROOT_CERT=">>vault:pki/root/generate/internal#certificate"
+  export ROOT_CERT_CACHED=">>vault:pki/root/generate/internal#certificate"
+
+  run_output=$(./secret-init env | grep 'FILE_SECRET\|MYSQL_PASSWORD\|SCHEME_SECRET\|ROOT_CERT\|ROOT_CERT_CACHED')
+  assert_success
+
+  assert_output_contains "FILE_SECRET=secret-value" "$run_output"
+  assert_output_contains "MYSQL_PASSWORD=modify3d3xtr3ms3cr3t" "$run_output"
+  assert_output_contains "SCHEME_SECRET=scheme://sch3m3s3cr3tONE:sch3m3s3cr3tTWO@$VAULT_ADDR" "$run_output"
+
+  [ $ROOT_CERT == $ROOT_CERT_CACHED ]
+  assert_success "ROOT_CERT and ROOT_CERT_CACHED are not the same"
+}

--- a/e2e/vault-provider.bats
+++ b/e2e/vault-provider.bats
@@ -15,9 +15,9 @@ setup_vault_provider() {
   export VAULT_ADDR="http://127.0.0.1:8200"
   export VAULT_TOKEN_FILE="$TMPFILE_TOKEN"
 
-  export MYSQL_PASSWORD=vault:secret/data/test/mysql#MYSQL_PASSWORD
-  export AWS_SECRET_ACCESS_KEY=vault:secret/data/test/aws#AWS_SECRET_ACCESS_KEY
-  export AWS_ACCESS_KEY_ID=vault:secret/data/test/aws#AWS_ACCESS_KEY_ID
+  export MYSQL_PASSWORD="vault:secret/data/test/mysql#MYSQL_PASSWORD"
+  export AWS_SECRET_ACCESS_KEY="vault:secret/data/test/aws#AWS_SECRET_ACCESS_KEY"
+  export AWS_ACCESS_KEY_ID="vault:secret/data/test/aws#AWS_ACCESS_KEY_ID"
 
   start_vault
 }
@@ -50,21 +50,23 @@ add_secrets_to_vault() {
   docker exec "$vault_container_name" vault kv put secret/test/aws AWS_ACCESS_KEY_ID=secretId AWS_SECRET_ACCESS_KEY=s3cr3t
 }
 
-remove_secrets_from_vault() {
-  docker exec "$vault_container_name" vault kv delete secret/test/mysql
-  docker exec "$vault_container_name" vault kv delete secret/test/aws
+add_custom_secret_to_vault() {
+  local path="$1"
+  shift
+  local data=()
+
+  for secret in "$@"; do
+    data+=("$secret")
+  done
+
+  vault kv put "$path" "${data[@]}"
 }
 
 teardown() {
-  stop_vault
+  docker compose down
 
   rm -f "$TMPFILE_TOKEN"
   rm -f secret-init
-}
-
-stop_vault() {
-  remove_secrets_from_vault
-  docker compose down
 }
 
 assert_output_contains() {
@@ -146,4 +148,32 @@ check_process_status() {
   assert_output_contains "MYSQL_PASSWORD=3xtr3ms3cr3t" "$run_output"
   assert_output_contains "AWS_SECRET_ACCESS_KEY=s3cr3t" "$run_output"
   assert_output_contains "AWS_ACCESS_KEY_ID=secretId" "$run_output"
+}
+
+@test "secrets sucessfully loaded from vault using different injection cases" {
+  setup_vault_provider
+  set_vault_token 227e1cce-6bf7-30bb-2d2a-acc854318caf
+  add_secrets_to_vault
+
+  # Secret with version
+  add_custom_secret_to_vault "secret/test/mysql" "MYSQL_PASSWORD=modify3d3xtr3ms3cr3t"
+  export MYSQL_PASSWORD="vault:secret/data/test/mysql#MYSQL_PASSWORD#2"
+
+  # Inline secrets with scheme
+  add_custom_secret_to_vault "secret/test/scheme" "SCHEME_SECRET1=sch3m3s3cr3tONE" "SCHEME_SECRET2=sch3m3s3cr3tTWO"
+  export SCHEME_SECRET="scheme://\${vault:secret/data/test/scheme#SCHEME_SECRET1}:\${vault:secret/data/test/scheme#SCHEME_SECRET2}@$VAULT_ADDR"
+
+  # Enable pki secrets engine and generate root certificates
+  vault secrets enable -path=pki pki
+  export ROOT_CERT=">>vault:pki/root/generate/internal#certificate"
+  export ROOT_CERT_CACHED=">>vault:pki/root/generate/internal#certificate"
+
+  run_output=$(./secret-init env | grep 'MYSQL_PASSWORD\|SCHEME_SECRET\|ROOT_CERT\|ROOT_CERT_CACHED')
+  assert_success
+
+  assert_output_contains "MYSQL_PASSWORD=modify3d3xtr3ms3cr3t" "$run_output"
+  assert_output_contains "SCHEME_SECRET=scheme://sch3m3s3cr3tONE:sch3m3s3cr3tTWO@$VAULT_ADDR" "$run_output"
+
+  [ $ROOT_CERT == $ROOT_CERT_CACHED ]
+  assert_success "ROOT_CERT and ROOT_CERT_CACHED are not the same"
 }

--- a/env_store.go
+++ b/env_store.go
@@ -18,7 +18,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -157,7 +159,11 @@ func getProviderPath(path string) (string, string) {
 		var fileProviderName = file.ProviderName
 		return fileProviderName, strings.TrimPrefix(path, "file:")
 	}
-	if strings.HasPrefix(path, "vault:") {
+	// If the path contains the "vault:" substring it is most probably a vault path
+	// otherwise the injector will not process it
+	re := regexp.MustCompile(`(vault:\w+)(\/\w+)`)
+	if re.MatchString(path) {
+		slog.Info("Detected vault path", "path", path)
 		var vaultProviderName = vault.ProviderName
 		// Do not remove the prefix since it will be processed during injection
 		return vaultProviderName, path

--- a/env_store.go
+++ b/env_store.go
@@ -163,7 +163,6 @@ func getProviderPath(path string) (string, string) {
 	// otherwise the injector will not process it
 	re := regexp.MustCompile(`(vault:\w+)(\/\w+)`)
 	if re.MatchString(path) {
-		slog.Info("Detected vault path", "path", path)
 		var vaultProviderName = vault.ProviderName
 		// Do not remove the prefix since it will be processed during injection
 		return vaultProviderName, path

--- a/env_store.go
+++ b/env_store.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"os"
 	"regexp"
 	"strings"

--- a/env_store.go
+++ b/env_store.go
@@ -158,9 +158,9 @@ func getProviderPath(path string) (string, string) {
 		var fileProviderName = file.ProviderName
 		return fileProviderName, strings.TrimPrefix(path, "file:")
 	}
-	// If the path contains the "vault:" substring it is most probably a vault path
-	// otherwise the injector will not process it
-	re := regexp.MustCompile(`(vault:\w+)(\/\w+)`)
+	// If the path contains some string formatted as "vault:{STR}#{STR}"
+	// it is most probably a vault path
+	re := regexp.MustCompile(`(vault:)(.*)#(.*)`)
 	if re.MatchString(path) {
 		var vaultProviderName = vault.ProviderName
 		// Do not remove the prefix since it will be processed during injection

--- a/env_store_test.go
+++ b/env_store_test.go
@@ -91,7 +91,7 @@ func TestEnvStore_GetProviderPaths(t *testing.T) {
 				os.Setenv(envKey, envVal)
 			}
 			t.Cleanup(func() {
-				defer os.Clearenv()
+				os.Clearenv()
 			})
 
 			paths := NewEnvStore().GetProviderPaths()

--- a/provider/file/config_test.go
+++ b/provider/file/config_test.go
@@ -47,7 +47,9 @@ func TestConfig(t *testing.T) {
 			for envKey, envVal := range ttp.env {
 				os.Setenv(envKey, envVal)
 			}
-			defer os.Clearenv()
+			t.Cleanup(func() {
+				defer os.Clearenv()
+			})
 
 			config := LoadConfig()
 

--- a/provider/file/config_test.go
+++ b/provider/file/config_test.go
@@ -48,7 +48,7 @@ func TestConfig(t *testing.T) {
 				os.Setenv(envKey, envVal)
 			}
 			t.Cleanup(func() {
-				defer os.Clearenv()
+				os.Clearenv()
 			})
 
 			config := LoadConfig()

--- a/provider/vault/config_test.go
+++ b/provider/vault/config_test.go
@@ -113,7 +113,7 @@ func TestConfig(t *testing.T) {
 				os.Setenv(envKey, envVal)
 			}
 			t.Cleanup(func() {
-				defer os.Clearenv()
+				os.Clearenv()
 			})
 
 			config, err := LoadConfig()

--- a/provider/vault/config_test.go
+++ b/provider/vault/config_test.go
@@ -112,7 +112,9 @@ func TestConfig(t *testing.T) {
 			for envKey, envVal := range ttp.env {
 				os.Setenv(envKey, envVal)
 			}
-			defer os.Clearenv()
+			t.Cleanup(func() {
+				defer os.Clearenv()
+			})
 
 			config, err := LoadConfig()
 			if err != nil {


### PR DESCRIPTION
## Overview

- The `injector` already utilizes a bunch of things, to detect vault secret references.
- On the side of `secret-init` it's sufficient if we use a regex to detect `vault:something/something/...` like substrings in the env-values, since it won't mistake `vault` like env-values for vault references, and if somehow a non-vault reference would be detected, the injector would just ignore it.
- Added an e2e test case to test different injection scenarios.

Fixes #68 

