### PR TITLE
feat: AWS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 |  Local provider                                              | ✅ Implemented  |
 | [HashiCorp Vault](https://www.vaultproject.io)               | ✅ Implemented  |
 | [OpenBao](https://github.com/openbao/openbao)                | ✅ Implemented  |
-| [AWS Secrets Manager](https://aws.amazon.com/secrets-manager)| Upcoming       |
+| [AWS Secrets Manager](https://aws.amazon.com/secrets-manager)| ✅ Implemented  |
 
 ## Getting started
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   vault:
     container_name: secret-init-vault

--- a/env_store.go
+++ b/env_store.go
@@ -86,7 +86,7 @@ func (s *EnvStore) GetSecretReferences() map[string][]string {
 
 // LoadProviderSecrets creates a new provider for each detected provider using a specified config.
 // It then asynchronously loads secrets using each provider and it's corresponding paths.
-// The secrets from each provider are then placed into a map with the provider name as the key.
+// The secrets from each provider are then placed into a single slice.
 func (s *EnvStore) LoadProviderSecrets(providerPaths map[string][]string) ([]provider.Secret, error) {
 	// At most, we will have one error per provider
 	errCh := make(chan error, len(supportedProviders))

--- a/env_store.go
+++ b/env_store.go
@@ -87,7 +87,7 @@ func (s *EnvStore) GetSecretReferences() map[string][]string {
 // LoadProviderSecrets creates a new provider for each detected provider using a specified config.
 // It then asynchronously loads secrets using each provider and it's corresponding paths.
 // The secrets from each provider are then placed into a single slice.
-func (s *EnvStore) LoadProviderSecrets(providerPaths map[string][]string) ([]provider.Secret, error) {
+func (s *EnvStore) LoadProviderSecrets(ctx context.Context, providerPaths map[string][]string) ([]provider.Secret, error) {
 	// At most, we will have one error per provider
 	errCh := make(chan error, len(supportedProviders))
 	var providerSecrets []provider.Secret
@@ -121,7 +121,7 @@ func (s *EnvStore) LoadProviderSecrets(providerPaths map[string][]string) ([]pro
 				return
 			}
 
-			secrets, err := provider.LoadSecrets(context.Background(), paths)
+			secrets, err := provider.LoadSecrets(ctx, paths)
 			if err != nil {
 				errCh <- fmt.Errorf("failed to load secrets for provider %s: %w", providerName, err)
 				return

--- a/env_store.go
+++ b/env_store.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/bank-vaults/secret-init/pkg/common"
 	"github.com/bank-vaults/secret-init/pkg/provider"
+	"github.com/bank-vaults/secret-init/pkg/provider/aws"
 	"github.com/bank-vaults/secret-init/pkg/provider/bao"
 	"github.com/bank-vaults/secret-init/pkg/provider/file"
 	"github.com/bank-vaults/secret-init/pkg/provider/vault"
@@ -33,6 +34,7 @@ var supportedProviders = []string{
 	file.ProviderName,
 	vault.ProviderName,
 	bao.ProviderName,
+	aws.ProviderName,
 }
 
 // EnvStore is a helper for managing interactions between environment variables and providers,
@@ -57,29 +59,29 @@ func NewEnvStore(appConfig *common.Config) *EnvStore {
 	}
 }
 
-// GetProviderPaths returns a map of secret paths for each provider
-func (s *EnvStore) GetProviderPaths() map[string][]string {
-	providerPaths := make(map[string][]string)
+// GetSecretReferences returns a map of secret key=value pairs for each provider
+func (s *EnvStore) GetSecretReferences() map[string][]string {
+	secretReferences := make(map[string][]string)
 
-	for envKey, path := range s.data {
-		providerName, path := getProviderPath(path)
+	for envKey, envPath := range s.data {
+		providerName, envSecretReference := getProviderPath(envPath)
+		envSecretReference = envKey + "=" + envSecretReference
 		switch providerName {
 		case file.ProviderName:
-			providerPaths[file.ProviderName] = append(providerPaths[file.ProviderName], path)
+			secretReferences[file.ProviderName] = append(secretReferences[file.ProviderName], envSecretReference)
 
 		case vault.ProviderName:
-			// The injector function expects a map of key:value pairs
-			path = envKey + "=" + path
-			providerPaths[vault.ProviderName] = append(providerPaths[vault.ProviderName], path)
+			secretReferences[vault.ProviderName] = append(secretReferences[vault.ProviderName], envSecretReference)
 
 		case bao.ProviderName:
-			// The injector function expects a map of key:value pairs
-			path = envKey + "=" + path
-			providerPaths[bao.ProviderName] = append(providerPaths[bao.ProviderName], path)
+			secretReferences[bao.ProviderName] = append(secretReferences[bao.ProviderName], envSecretReference)
+
+		case aws.ProviderName:
+			secretReferences[aws.ProviderName] = append(secretReferences[aws.ProviderName], envSecretReference)
 		}
 	}
 
-	return providerPaths
+	return secretReferences
 }
 
 // LoadProviderSecrets creates a new provider for each detected provider using a specified config.
@@ -170,21 +172,9 @@ func (s *EnvStore) workaroundForBao(vaultPaths []string) ([]provider.Secret, err
 func (s *EnvStore) ConvertProviderSecrets(providerSecrets map[string][]provider.Secret) ([]string, error) {
 	var secretsEnv []string
 
-	for providerName, secrets := range providerSecrets {
-		switch providerName {
-		case vault.ProviderName, bao.ProviderName:
-			// The Vault and Bao providers already returns the secrets with the environment variable keys
-			for _, secret := range secrets {
-				secretsEnv = append(secretsEnv, fmt.Sprintf("%s=%s", secret.Path, secret.Value))
-			}
-
-		default:
-			secrets, err := createSecretEnvsFrom(s.data, secrets)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create secret environment variables: %w", err)
-			}
-
-			secretsEnv = append(secretsEnv, secrets...)
+	for _, secrets := range providerSecrets {
+		for _, secret := range secrets {
+			secretsEnv = append(secretsEnv, fmt.Sprintf("%s=%s", secret.Key, secret.Value))
 		}
 	}
 
@@ -194,22 +184,26 @@ func (s *EnvStore) ConvertProviderSecrets(providerSecrets map[string][]provider.
 // Returns the detected provider name and path with removed prefix
 func getProviderPath(path string) (string, string) {
 	if strings.HasPrefix(path, "file:") {
-		var fileProviderName = file.ProviderName
-		return fileProviderName, strings.TrimPrefix(path, "file:")
+		return file.ProviderName, path
 	}
 
 	// If the path contains some string formatted as "vault:{STR}#{STR}"
 	// it is most probably a vault path
 	if vault.ProviderEnvRegex.MatchString(path) {
-		// Do not remove the prefix since it will be processed during injection
 		return vault.ProviderName, path
 	}
 
 	// If the path contains some string formatted as "bao:{STR}#{STR}"
 	// it is most probably a vault path
 	if bao.ProviderEnvRegex.MatchString(path) {
-		// Do not remove the prefix since it will be processed during injection
 		return bao.ProviderName, path
+	}
+
+	// Example AWS prefixes:
+	// arn:aws:secretsmanager:us-west-2:123456789012:secret:my-secret
+	// arn:aws:ssm:us-west-2:123456789012:parameter/my-parameter
+	if strings.HasPrefix(path, "arn:aws:secretsmanager:") || strings.HasPrefix(path, "arn:aws:ssm:") {
+		return aws.ProviderName, path
 	}
 
 	return "", path
@@ -249,33 +243,16 @@ func newProvider(providerName string, appConfig *common.Config) (provider.Provid
 		}
 		return provider, nil
 
+	case aws.ProviderName:
+		config, err := aws.LoadConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create aws config: %w", err)
+		}
+
+		provider := aws.NewProvider(config)
+		return provider, nil
+
 	default:
 		return nil, fmt.Errorf("provider %s is not supported", providerName)
 	}
-}
-
-func createSecretEnvsFrom(envs map[string]string, secrets []provider.Secret) ([]string, error) {
-	// Reverse the map so we can match
-	// the environment variable key to the secret
-	// by using the secret path
-	reversedEnvs := make(map[string]string)
-	for envKey, path := range envs {
-		providerName, path := getProviderPath(path)
-		if providerName != "" {
-			reversedEnvs[path] = envKey
-		}
-	}
-
-	var secretsEnv []string
-	for _, secret := range secrets {
-		path := secret.Path
-		key, ok := reversedEnvs[path]
-		if !ok {
-			return nil, fmt.Errorf("failed to find environment variable key for secret path: %s", path)
-		}
-
-		secretsEnv = append(secretsEnv, fmt.Sprintf("%s=%s", key, secret.Value))
-	}
-
-	return secretsEnv, nil
 }

--- a/env_store_test.go
+++ b/env_store_test.go
@@ -161,7 +161,7 @@ func TestEnvStore_LoadProviderSecrets(t *testing.T) {
 	tests := []struct {
 		name                string
 		providerPaths       map[string][]string
-		wantProviderSecrets map[string][]provider.Secret
+		wantProviderSecrets []provider.Secret
 		addvault            bool
 		err                 error
 	}{
@@ -172,12 +172,10 @@ func TestEnvStore_LoadProviderSecrets(t *testing.T) {
 					"AWS_SECRET_ACCESS_KEY_ID=file:" + secretFile,
 				},
 			},
-			wantProviderSecrets: map[string][]provider.Secret{
-				"file": {
-					{
-						Key:   "AWS_SECRET_ACCESS_KEY_ID",
-						Value: "secretId",
-					},
+			wantProviderSecrets: []provider.Secret{
+				{
+					Key:   "AWS_SECRET_ACCESS_KEY_ID",
+					Value: "secretId",
 				},
 			},
 			addvault: false,
@@ -216,19 +214,17 @@ func TestEnvStore_ConvertProviderSecrets(t *testing.T) {
 
 	tests := []struct {
 		name            string
-		providerSecrets map[string][]provider.Secret
+		providerSecrets []provider.Secret
 		wantSecretsEnv  []string
 		addvault        bool
 		err             error
 	}{
 		{
 			name: "Convert secrets successfully",
-			providerSecrets: map[string][]provider.Secret{
-				"file": {
-					{
-						Key:   "AWS_SECRET_ACCESS_KEY_ID",
-						Value: "secretId",
-					},
+			providerSecrets: []provider.Secret{
+				{
+					Key:   "AWS_SECRET_ACCESS_KEY_ID",
+					Value: "secretId",
 				},
 			},
 			wantSecretsEnv: []string{

--- a/env_store_test.go
+++ b/env_store_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -197,7 +198,7 @@ func TestEnvStore_LoadProviderSecrets(t *testing.T) {
 		t.Run(ttp.name, func(t *testing.T) {
 			createEnvsForProvider(ttp.addvault, secretFile)
 
-			providerSecrets, err := NewEnvStore(&common.Config{}).LoadProviderSecrets(ttp.providerPaths)
+			providerSecrets, err := NewEnvStore(&common.Config{}).LoadProviderSecrets(context.Background(), ttp.providerPaths)
 			if err != nil {
 				assert.EqualError(t, ttp.err, err.Error(), "Unexpected error message")
 			}

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,6 +7,7 @@ Discover a range of examples that highlight the functionalities of **secret-init
 - [File provider](file-provider.md)
 - [Vault provider](vault-provider.md)
 - [Bao provider](bao-provider.md)
+- [AWS provider](aws-provider.md)
 
 ## Multi provider use-case
 

--- a/examples/aws-provider.md
+++ b/examples/aws-provider.md
@@ -8,6 +8,7 @@ The AWS Provider in Secret-init can load secrets from AWS Secrets Manager and AW
 
 - Golang `>= 1.21`
 - Makefile
+- Access to AWS services
 
 ## Environment setup
 
@@ -23,8 +24,8 @@ export AWS_REGION
 ```bash
 # Export environment variables
 export MYSQL_PASSWORD=arn:aws:secretsmanager:eu-north-1:123456789:secret:secret/test/mysql-ASD123
-export SSM_SECRET=arn:aws:ssm:eu-north-1:123456789:parameter/bank-vaults/test
 export SM_JSON=arn:aws:secretsmanager:eu-north-1:123456789:secret:test/secret/JSON-ASD123
+export SSM_SECRET=arn:aws:ssm:eu-north-1:123456789:parameter/bank-vaults/test
 
 # NOTE: Secret-init is designed to identify any secret-reference that starts with "arn:aws:secretsmanager:" or "arn:aws:ssm:"
 ```
@@ -39,7 +40,10 @@ go build
 SECRET_INIT_DAEMON="true"
 
 # Run secret-init with a command e.g.
-./secret-init env | grep 'SM_JSON\|MYSQL_PASSWORD\|firsts3cr3t\|seconds3cr3t\|SSM_SECRET'
+./secret-init env | grep 'MYSQL_PASSWORD\|SM_JSON\|SSM_SECRET'
+
+# JSON secrets are loaded as is:
+# SM_JSON="{"firsts3cr3t":"s3cr3ton3","seconds3cr3t":"s3cr3ttwo"}"
 ```
 
 ## Cleanup

--- a/examples/aws-provider.md
+++ b/examples/aws-provider.md
@@ -1,0 +1,55 @@
+# AWS-provider
+
+## Overview
+
+The AWS Provider in Secret-init can load secrets from AWS Secrets Manager and AWS Systems Manager (SSM) Parameter Store as well.
+
+## Prerequisites
+
+- Golang `>= 1.21`
+- Makefile
+
+## Environment setup
+
+```bash
+# Secret-ini requires atleast these environment variables to be set properly
+export AWS_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY
+export AWS_REGION
+```
+
+## Define secrets to inject
+
+```bash
+# Export environment variables
+export MYSQL_PASSWORD=arn:aws:secretsmanager:eu-north-1:123456789:secret:secret/test/mysql-ASD123
+export SSM_SECRET=arn:aws:ssm:eu-north-1:123456789:parameter/bank-vaults/test
+export SM_JSON=arn:aws:secretsmanager:eu-north-1:123456789:secret:test/secret/JSON-ASD123
+
+# NOTE: Secret-init is designed to identify any secret-reference that starts with "arn:aws:secretsmanager:" or "arn:aws:ssm:"
+```
+
+## Run secret-init
+
+```bash
+# Build the secret-init binary
+go build
+
+# Use in daemon mode
+SECRET_INIT_DAEMON="true"
+
+# Run secret-init with a command e.g.
+./secret-init env | grep 'SM_JSON\|MYSQL_PASSWORD\|firsts3cr3t\|seconds3cr3t\|SSM_SECRET'
+```
+
+## Cleanup
+
+```bash
+# Remove binary
+rm -rf secret-init
+
+# Unset the environment variables
+unset MYSQL_PASSWORD
+unset SM_JSON
+unset SSM_SECRET
+```

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21.1
 
 require (
 	emperror.dev/errors v0.8.1
+	github.com/aws/aws-sdk-go v1.51.6
 	github.com/bank-vaults/internal v0.3.0
 	github.com/bank-vaults/vault-sdk v0.9.3
 	github.com/hashicorp/vault/api v1.12.2
@@ -30,7 +31,6 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
-	github.com/aws/aws-sdk-go v1.51.6 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.25.3 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.1 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.27.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/bank-vaults/secret-init
 go 1.21.1
 
 require (
-	emperror.dev/errors v0.8.1
 	github.com/aws/aws-sdk-go v1.51.6
 	github.com/bank-vaults/internal v0.3.0
 	github.com/bank-vaults/vault-sdk v0.9.3
@@ -21,6 +20,7 @@ require (
 	cloud.google.com/go/iam v1.1.6 // indirect
 	cloud.google.com/go/kms v1.15.8 // indirect
 	cloud.google.com/go/storage v1.39.1 // indirect
+	emperror.dev/errors v0.8.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.10.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2 // indirect

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func main() {
 
 	secretReferences := envStore.GetSecretReferences()
 
-	providerSecrets, err := envStore.LoadProviderSecrets(secretReferences)
+	providerSecrets, err := envStore.LoadProviderSecrets(context.Background(), secretReferences)
 	if err != nil {
 		slog.Error(fmt.Errorf("failed to extract secrets: %w", err).Error())
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -52,9 +52,9 @@ func main() {
 	// Fetch all provider secrets and assemble env variables using envstore
 	envStore := NewEnvStore(config)
 
-	providerPaths := envStore.GetProviderPaths()
+	secretReferences := envStore.GetSecretReferences()
 
-	providerSecrets, err := envStore.LoadProviderSecrets(providerPaths)
+	providerSecrets, err := envStore.LoadProviderSecrets(secretReferences)
 	if err != nil {
 		slog.Error(fmt.Errorf("failed to extract secrets: %w", err).Error())
 		os.Exit(1)

--- a/pkg/provider/aws/aws.go
+++ b/pkg/provider/aws/aws.go
@@ -1,0 +1,150 @@
+// Copyright © 2024 Bank-Vaults Maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"emperror.dev/errors"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/aws/aws-sdk-go/service/ssm"
+
+	"github.com/bank-vaults/secret-init/pkg/provider"
+)
+
+var ProviderName = "aws"
+
+type Provider struct {
+	sm  *secretsmanager.SecretsManager
+	ssm *ssm.SSM
+}
+
+func NewProvider(config *Config) *Provider {
+	return &Provider{
+		sm:  secretsmanager.New(config.session),
+		ssm: ssm.New(config.session),
+	}
+}
+
+func (p *Provider) LoadSecrets(_ context.Context, paths []string) ([]provider.Secret, error) {
+	var secrets []provider.Secret
+
+	for _, path := range paths {
+		split := strings.SplitN(path, "=", 2)
+		originalKey, secretID := split[0], split[1]
+
+		// valid secretsmanager secret examples:
+		// arn:aws:secretsmanager:region:account-id:secret:secret-name
+		// secretsmanager:secret-name
+		if strings.Contains(secretID, "secretsmanager:") {
+			secret, err := p.sm.GetSecretValue(
+				&secretsmanager.GetSecretValueInput{
+					SecretId: aws.String(secretID),
+				})
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to get secret from AWS secrets manager")
+			}
+
+			if json.Valid([]byte(*secret.SecretString)) {
+				var secretValue map[string]interface{}
+				err := json.Unmarshal([]byte(*secret.SecretString), &secretValue)
+				if err != nil {
+					return nil, errors.Wrap(err, "failed to unmarshal secret value")
+				}
+
+				// If there is only one key in the secret, append it directly
+				if len(secretValue) == 1 {
+					for _, value := range secretValue {
+						secretToAppend, err := appendSecret(originalKey, value)
+						if err != nil {
+							return nil, errors.Wrap(err, "failed to append secret")
+						}
+
+						secrets = append(secrets, secretToAppend)
+					}
+
+					continue
+				}
+
+				// If the secret is a JSON object, append it as a single secret
+				JSONValue, err := json.Marshal(secretValue)
+				if err != nil {
+					return nil, errors.Wrap(err, "failed to marshal secret value")
+				}
+
+				secretToAppend, err := appendSecret(originalKey, JSONValue)
+				if err != nil {
+					return nil, errors.Wrap(err, "failed to append secret")
+				}
+
+				secrets = append(secrets, secretToAppend)
+
+			} else {
+				// If the secret is not a JSON object, append it directly
+				secretToAppend, err := appendSecret(originalKey, aws.StringValue(secret.SecretString))
+				if err != nil {
+					return nil, errors.Wrap(err, "failed to append secret")
+				}
+
+				secrets = append(secrets, secretToAppend)
+			}
+		}
+
+		// Valid ssm parameter examples:
+		// arn:aws:ssm:region:account-id:parameter/path/to/parameter-name
+		// arn:aws:ssm:us-west-2:123456789012:parameter/my-parameter
+		if strings.Contains(secretID, "ssm:") {
+			parameteredSecret, err := p.ssm.GetParameter(
+				&ssm.GetParameterInput{
+					Name:           aws.String(secretID),
+					WithDecryption: aws.Bool(true),
+				})
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to get parameter from AWS SSM")
+			}
+
+			secretToAppend, err := appendSecret(originalKey, *parameteredSecret.Parameter.Value)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to append secret")
+			}
+
+			secrets = append(secrets, secretToAppend)
+		}
+	}
+
+	return secrets, nil
+}
+
+func appendSecret(key string, value interface{}) (provider.Secret, error) {
+	switch v := value.(type) {
+	case string:
+		return provider.Secret{
+			Key:   key,
+			Value: v,
+		}, nil
+
+	case []byte:
+		return provider.Secret{
+			Key:   key,
+			Value: string(v),
+		}, nil
+
+	default:
+		return provider.Secret{}, errors.New("unsupported secret value type")
+	}
+}

--- a/pkg/provider/aws/aws.go
+++ b/pkg/provider/aws/aws.go
@@ -60,9 +60,9 @@ func (p *Provider) LoadSecrets(_ context.Context, paths []string) ([]provider.Se
 				return nil, errors.Wrap(err, "failed to get secret from AWS secrets manager")
 			}
 
-			if json.Valid([]byte(*secret.SecretString)) {
+			if json.Valid([]byte(aws.StringValue(secret.SecretString))) {
 				var secretValue map[string]interface{}
-				err := json.Unmarshal([]byte(*secret.SecretString), &secretValue)
+				err := json.Unmarshal([]byte(aws.StringValue(secret.SecretString)), &secretValue)
 				if err != nil {
 					return nil, errors.Wrap(err, "failed to unmarshal secret value")
 				}
@@ -93,7 +93,6 @@ func (p *Provider) LoadSecrets(_ context.Context, paths []string) ([]provider.Se
 				}
 
 				secrets = append(secrets, secretToAppend)
-
 			} else {
 				// If the secret is not a JSON object, append it directly
 				secretToAppend, err := appendSecret(originalKey, aws.StringValue(secret.SecretString))
@@ -118,7 +117,7 @@ func (p *Provider) LoadSecrets(_ context.Context, paths []string) ([]provider.Se
 				return nil, errors.Wrap(err, "failed to get parameter from AWS SSM")
 			}
 
-			secretToAppend, err := appendSecret(originalKey, *parameteredSecret.Parameter.Value)
+			secretToAppend, err := appendSecret(originalKey, aws.StringValue(parameteredSecret.Parameter.Value))
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to append secret")
 			}

--- a/pkg/provider/aws/aws_test.go
+++ b/pkg/provider/aws/aws_test.go
@@ -1,0 +1,55 @@
+// Copyright © 2024 Bank-Vaults Maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewProvider(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   *Config
+		wantType bool
+	}{
+		{
+			name: "Valid config",
+			config: &Config{
+				session: createSession(),
+			},
+			wantType: true,
+		},
+	}
+
+	for _, tt := range tests {
+		ttp := tt
+		t.Run(ttp.name, func(t *testing.T) {
+			provider := NewProvider(ttp.config)
+			if ttp.wantType {
+				assert.Equal(t, ttp.wantType, provider != nil, "Unexpected provider type")
+			}
+		})
+	}
+
+}
+
+func createSession() *session.Session {
+	return session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigDisable,
+	}))
+}

--- a/pkg/provider/aws/config.go
+++ b/pkg/provider/aws/config.go
@@ -15,9 +15,9 @@
 package aws
 
 import (
+	"fmt"
 	"os"
 
-	"emperror.dev/errors"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/spf13/cast"
@@ -45,15 +45,14 @@ func LoadConfig() (*Config, error) {
 		options.SharedConfigState = session.SharedConfigEnable
 	}
 
-	RegionEnv := getRegionEnv()
-	if RegionEnv != nil {
-		options.Config = aws.Config{Region: RegionEnv}
+	if region := getRegionEnv(); region != nil {
+		options.Config = aws.Config{Region: region}
 	}
 
 	// Create session
 	sess, err := session.NewSessionWithOptions(options)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create AWS session")
+		return nil, fmt.Errorf("failed to create AWS session: %w", err)
 	}
 
 	return &Config{session: sess}, nil

--- a/pkg/provider/aws/config.go
+++ b/pkg/provider/aws/config.go
@@ -1,0 +1,80 @@
+// Copyright © 2024 Bank-Vaults Maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"os"
+
+	"emperror.dev/errors"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/spf13/cast"
+)
+
+const (
+	LoadFromSharedConfigEnv = "AWS_LOAD_FROM_SHARED_CONFIG"
+	DefaultRegionEnv        = "AWS_DEFAULT_REGION"
+	RegionEnv               = "AWS_REGION"
+)
+
+type Config struct {
+	session *session.Session
+}
+
+func LoadConfig() (*Config, error) {
+	region, err := getRegion()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get region")
+	}
+
+	// SharedConfigDisable is the default state,
+	// and will use the AWS_SDK_LOAD_CONFIG environment variable.
+	// LoadFromSharedConfigEnv can be used to enable loading from AWS shared config.
+	var sess *session.Session
+	loadFromSharedConfig := cast.ToBool(os.Getenv(LoadFromSharedConfigEnv))
+	if loadFromSharedConfig {
+		sess = session.Must(session.NewSessionWithOptions(
+			session.Options{
+				Config: aws.Config{
+					Region: region,
+				},
+				SharedConfigState: session.SharedConfigEnable,
+			}))
+	} else {
+		sess = session.Must(session.NewSessionWithOptions(
+			session.Options{
+				Config: aws.Config{
+					Region: region,
+				},
+				SharedConfigState: session.SharedConfigDisable,
+			}))
+	}
+
+	return &Config{session: sess}, nil
+}
+
+func getRegion() (*string, error) {
+	region, hasRegion := os.LookupEnv(RegionEnv)
+	if !hasRegion {
+		defaultRegion, hasDefaultRegion := os.LookupEnv(DefaultRegionEnv)
+		if hasDefaultRegion {
+			return &defaultRegion, nil
+		}
+
+		return nil, errors.New("no region found")
+	}
+
+	return &region, nil
+}

--- a/pkg/provider/bao/bao.go
+++ b/pkg/provider/bao/bao.go
@@ -56,10 +56,9 @@ func (s *sanitized) append(key string, value string) {
 	// it is not a BAO_* variable.
 	// Additionally, in a login scenario, we include BAO_* variables in the secrets list.
 	if !ok || (s.login && envType.login) {
-		// Path here is actually the secret's key,
-		// An example of this can be found at the LoadSecrets() function below
+		// Example can be found at the LoadSecrets() function below
 		secret := provider.Secret{
-			Path:  key,
+			Key:   key,
 			Value: value,
 		}
 
@@ -159,8 +158,7 @@ func parsePathsToMap(paths []string) map[string]string {
 
 	for _, path := range paths {
 		split := strings.SplitN(path, "=", 2)
-		key := split[0]
-		value := split[1]
+		key, value := split[0], split[1]
 		baoEnviron[key] = value
 	}
 

--- a/pkg/provider/bao/daemon_secret_renewer.go
+++ b/pkg/provider/bao/daemon_secret_renewer.go
@@ -15,12 +15,12 @@
 package bao
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"syscall"
 	"time"
 
-	"emperror.dev/errors"
 	bao "github.com/bank-vaults/vault-sdk/vault"
 	baoapi "github.com/hashicorp/vault/api"
 )
@@ -34,7 +34,7 @@ func (r daemonSecretRenewer) Renew(path string, secret *baoapi.Secret) error {
 	watcherInput := baoapi.LifetimeWatcherInput{Secret: secret}
 	watcher, err := r.client.RawClient().NewLifetimeWatcher(&watcherInput)
 	if err != nil {
-		return errors.Wrap(err, "failed to create secret watcher")
+		return fmt.Errorf("failed to create lifetime watcher: %w", err)
 	}
 
 	go watcher.Start()

--- a/pkg/provider/file/file.go
+++ b/pkg/provider/file/file.go
@@ -48,23 +48,27 @@ func (p *Provider) LoadSecrets(_ context.Context, paths []string) ([]provider.Se
 	var secrets []provider.Secret
 
 	for _, path := range paths {
-		secret, err := p.getSecretFromFile(path)
+		split := strings.SplitN(path, "=", 2)
+		key, valuePath := split[0], split[1]
+		valuePath = strings.TrimPrefix(valuePath, "file:")
+
+		secretValue, err := p.getSecretFromFile(valuePath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get secret from file: %w", err)
 		}
 
 		secrets = append(secrets, provider.Secret{
-			Path:  path,
-			Value: secret,
+			Key:   key,
+			Value: secretValue,
 		})
 	}
 
 	return secrets, nil
 }
 
-func (p *Provider) getSecretFromFile(path string) (string, error) {
-	path = strings.TrimLeft(path, "/")
-	content, err := fs.ReadFile(p.fs, path)
+func (p *Provider) getSecretFromFile(valuePath string) (string, error) {
+	valuePath = strings.TrimLeft(valuePath, "/")
+	content, err := fs.ReadFile(p.fs, valuePath)
 	if err != nil {
 		return "", fmt.Errorf("failed to read file: %w", err)
 	}

--- a/pkg/provider/file/file_test.go
+++ b/pkg/provider/file/file_test.go
@@ -91,22 +91,22 @@ func TestLoadSecrets(t *testing.T) {
 		{
 			name: "Load secrets successfully",
 			paths: []string{
-				"test/secrets/sqlpass.txt",
-				"test/secrets/awsaccess.txt",
-				"test/secrets/awsid.txt",
+				"MYSQL_PASSWORD=file:test/secrets/sqlpass.txt",
+				"AWS_SECRET_ACCESS_KEY=file:test/secrets/awsaccess.txt",
+				"AWS_ACCESS_KEY_ID=file:test/secrets/awsid.txt",
 			},
 			wantSecrets: []provider.Secret{
-				{Path: "test/secrets/sqlpass.txt", Value: "3xtr3ms3cr3t"},
-				{Path: "test/secrets/awsaccess.txt", Value: "s3cr3t"},
-				{Path: "test/secrets/awsid.txt", Value: "secretId"},
+				{Key: "MYSQL_PASSWORD", Value: "3xtr3ms3cr3t"},
+				{Key: "AWS_SECRET_ACCESS_KEY", Value: "s3cr3t"},
+				{Key: "AWS_ACCESS_KEY_ID", Value: "secretId"},
 			},
 		},
 		{
 			name: "Fail to load secrets due to invalid path",
 			paths: []string{
-				"test/secrets/mistake/sqlpass.txt",
-				"test/secrets/mistake/awsaccess.txt",
-				"test/secrets/mistake/awsid.txt",
+				"MYSQL_PASSWORD=file:test/secrets/mistake/sqlpass.txt",
+				"AWS_SECRET_ACCESS_KEY=file:test/secrets/mistake/awsaccess.txt",
+				"AWS_ACCESS_KEY_ID=file:test/secrets/mistake/awsid.txt",
 			},
 			err: fmt.Errorf("failed to get secret from file: failed to read file: open test/secrets/mistake/sqlpass.txt: file does not exist"),
 		},

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -23,6 +23,6 @@ type Provider interface {
 
 // Secret holds Provider-specific secret data.
 type Secret struct {
-	Path  string
+	Key   string
 	Value string
 }

--- a/pkg/provider/vault/daemon_secret_renewer.go
+++ b/pkg/provider/vault/daemon_secret_renewer.go
@@ -15,12 +15,12 @@
 package vault
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"syscall"
 	"time"
 
-	"emperror.dev/errors"
 	"github.com/bank-vaults/vault-sdk/vault"
 	vaultapi "github.com/hashicorp/vault/api"
 )
@@ -34,7 +34,7 @@ func (r daemonSecretRenewer) Renew(path string, secret *vaultapi.Secret) error {
 	watcherInput := vaultapi.LifetimeWatcherInput{Secret: secret}
 	watcher, err := r.client.RawClient().NewLifetimeWatcher(&watcherInput)
 	if err != nil {
-		return errors.Wrap(err, "failed to create secret watcher")
+		return fmt.Errorf("failed to create lifetime watcher: %w", err)
 	}
 
 	go watcher.Start()

--- a/pkg/provider/vault/vault.go
+++ b/pkg/provider/vault/vault.go
@@ -56,10 +56,9 @@ func (s *sanitized) append(key string, value string) {
 	// it is not a VAULT_* variable.
 	// Additionally, in a login scenario, we include VAULT_* variables in the secrets list.
 	if !ok || (s.login && envType.login) {
-		// Path here is actually the secret's key,
-		// An example of this can be found at the LoadSecrets() function below
+		// Example can be found at the LoadSecrets() function below
 		secret := provider.Secret{
-			Path:  key,
+			Key:   key,
 			Value: value,
 		}
 
@@ -159,8 +158,7 @@ func parsePathsToMap(paths []string) map[string]string {
 
 	for _, path := range paths {
 		split := strings.SplitN(path, "=", 2)
-		key := split[0]
-		value := split[1]
+		key, value := split[0], split[1]
 		vaultEnviron[key] = value
 	}
 


### PR DESCRIPTION
## Overview

- Added `AWS` provider to the project, it can load secrets from `AWS Secrets Manager` and `AWS Systems Manager` (SSM) Parameter Store as well.
- Simplified the env-var converter function, now its much cleaner.
- Removed Version from `docker-compose.yaml` since it is obsolete: https://docs.docker.com/compose/compose-file/04-version-and-name/
Fixes #90 

